### PR TITLE
Settings (chat color & ignore list)

### DIFF
--- a/css/hackmud.css
+++ b/css/hackmud.css
@@ -54,6 +54,10 @@ a:hover {
 	color: #3F3F3F;
 }
 
+.ignore {
+	opacity: 0.3;
+}
+
 .col-cap-A, .col-1 {
 	color: #FFFFFF;
 }

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 		<script src="js/lib/jquery-1.12.4.min.js"></script>
 		<script src="js/chat.js"></script>
 		<script src="js/messages.js"></script>
+		<script src="js/settings.js"></script>
 		<script src="js/ui.js"></script>
 		<link rel="stylesheet" href="css/main.css"></link>
 		<link rel="stylesheet" href="css/hackmud.css"></link>

--- a/js/messages.js
+++ b/js/messages.js
@@ -1,5 +1,6 @@
-function MessageList(channel) {
+function MessageList(channel, ul) {
 	this.channel = channel;
+	this.ul = ul;
 	this.messages = {};
 	this.ids = [];
 }
@@ -17,4 +18,54 @@ MessageList.prototype.poll = function() {
 
 		return recent;
 	});
+}
+
+MessageList.prototype.write = function(html, classArray) {
+	if (!classArray) {
+		classArray = [];
+	}
+
+	let li = $('<li class="' + classArray.join(' ') + '">');
+	li.html(html);
+	this.ul.append(li);
+}
+
+MessageList.prototype.safeWrite = function(str, classArray) {
+	this.write(escapeHtml(str), classArray);
+}
+
+// putting this on the MessageList class so that we have a way to output data
+MessageList.prototype.handleSlashCommand = function(str) {
+	var components = str.split(' ');
+
+	if (components[0] == 'help') {
+		this.safeWrite('Commands: /help, /ignore <user>, /color <letter|color code>');
+	} else if (components[0] == 'ignore') {
+		if (components[1]) {
+			var user = components[1];
+			settings.addIgnore(user);
+			this.safeWrite("Ignored " + user);
+		} else {
+			this.safeWrite("Ignore list: " + settings.ignore_list.join(", "));
+		}
+	} else if (components[0] == 'color') {
+		if (components[1]) {
+			var color = components[1];
+			settings.setColor(color);
+			this.write('Set chat color to "' + color + '". Sample: "' + colorCallback(null, color, 'foo bar baz') + '"');
+		} else {
+			if (settings.color_code) {
+				var color = settings.color_code;
+				this.write('Current chat color is "' + color + '". Sample: "' + colorCallback(null, color, 'foo bar baz') + '"');
+			} else {
+				this.safeWrite("Currently using the default chat color.");
+			}
+		}
+	}
+	
+	this.scrollToBottom();
+}
+
+MessageList.prototype.scrollToBottom = function() {
+	this.ul.scrollTop(1e10); // just scroll down a lot
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,27 @@
+function Settings() {
+	this.ignore_list = [];
+};
+
+Settings.prototype.setColor = function(code) {
+	this.color_code = code;
+	localStorage.setItem('color_code', JSON.stringify(code));
+}
+
+Settings.prototype.addIgnore = function(user) {
+	this.ignore_list.push(user);
+	localStorage.setItem('ignore_list', JSON.stringify(this.ignore_list));
+}
+
+var settings = new Settings();
+
+$(document).ready(function() {
+	[
+		'color_code',
+		'ignore_list',
+	].forEach(function(key) {
+		var data = localStorage.getItem(key);
+		if (data) {
+			settings[key] = JSON.parse(data);
+		}
+	});
+});


### PR DESCRIPTION
Clean version of #7, I hope.

Adds support for user settings, /-commands (such as /help), and two specific settings:

color_code, set with /color <char>: this automatically wraps your chats in color escape sequences. Something that portions of the playerbase built into their own chat scripts (only supports simple formatting, so far).
ignore_list, add users with /ignore <user>: displays messages from these users in a new, de-emphasized style (0.3 alpha).
This does use localStorage, and I haven't tested whether it breaks if that's disabled. I'll see if I can get someone to test that.

Depends on PR #5, since this makes use of the CSS added there.