### PR TITLE
Fix crash when processing chats.tell messages

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -108,7 +108,8 @@ function replaceUI() {
 					let channels = act.users[user].channels;
 
 					// new messages, in oldest-to-newest order
-					recent = data.chats[user].filter(m => !channels[m.channel].list.messages[m.id]);
+					// TODO deal with tells
+					recent = data.chats[user].filter(m => m.channel && !channels[m.channel].list.messages[m.id]);
 
 					recent.forEach(function(msg) {
 						channels[msg.channel].list.recordMessage(msg);


### PR DESCRIPTION
Fixes the error posted in #8. Doesn't implement #12 (add chats.tell support).