### PR TITLE
ASCII art and formatting fixes

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -5,6 +5,10 @@
 	line-height: 0.9em;
 }
 
+.message_list li {
+	margin: 0.5em 0;
+}
+
 .chat-input {
 	width: 90%;
 }

--- a/css/main.css
+++ b/css/main.css
@@ -1,6 +1,8 @@
 .message_list {
 	overflow-y: scroll;
 	max-height: 50%;
+	white-space: pre-wrap;
+	line-height: 0.9em;
 }
 
 .chat-input {


### PR DESCRIPTION
1. Stop collapsing spaces, so that ASCII art actually renders properly
2. Mimic the game's line-spacing
3. Add a blank line (using margins) between messages, so things are less squished