### PR TITLE
Colorize script-like things [closes #51]

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -220,10 +220,10 @@ function colorizeScripts(msg) {
 	];
 
 	return msg.replace(/([a-z_]\w*)\.([a-z_]\w*)/g, function(match, username, script) {
-		let colorCode = trustUsers.indexOf(username) !== -1 ? 'F' : 'C'
+		let colorCode = trustUsers.indexOf(username) !== -1 ? 'F' : 'C';
 
 		return replaceColorCodes('`' + colorCode + username + '`.`L' + script + '`');
-	})
+	});
 }
 
 function replaceColorCodes(string) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -24,8 +24,6 @@ function readCookieValue(key) {
 	return document.cookie.replace(new RegExp('(?:(?:^|.*;\\s*)' + key + '\\s*\\=\\s*([^;]*).*$)|^.*$'), "$1");
 }
 
-
-
 function setupChannel(user,chan_ul,user_div,chan,tell=false) {
 	let li = $('<li class="channel_tab">');
 	if(tell) {
@@ -58,7 +56,7 @@ function setupChannel(user,chan_ul,user_div,chan,tell=false) {
 
 		$('.channel_area').hide();
 		channel_div.show();
-		
+
 		list.scrollToBottom();
 	});
 
@@ -75,7 +73,7 @@ function setupChannel(user,chan_ul,user_div,chan,tell=false) {
 	form.submit(function() {
 		try {
 			let msg = input.val();
-			
+
 			if(msg.trim().length == 0) {
 				return false;
 			}
@@ -205,6 +203,29 @@ function colorizeMentions(msg) {
 	});
 }
 
+function colorizeScripts(msg) {
+	let trustUsers = [
+		'accts',
+		'autos',
+		'chats',
+		'corps',
+		'escrow',
+		'gui',
+		'kernel',
+		'market',
+		'scripts',
+		'sys',
+		'trust',
+		'users'
+	];
+
+	return msg.replace(/([a-z_]\w*)\.([a-z_]\w*)/g, function(match, username, script) {
+		let colorCode = trustUsers.indexOf(username) !== -1 ? 'F' : 'C'
+
+		return replaceColorCodes('`' + colorCode + username + '`.`L' + script + '`');
+	})
+}
+
 function replaceColorCodes(string) {
 	return string.replace(/`([0-9a-zA-Z])([^:`\n]{1,2}|[^`\n]{3,}?)`/g, colorCallback);
 }
@@ -215,6 +236,7 @@ function formatMessage(obj) {
 	let msg = escapeHtml(obj.msg);
 	let coloredUser = replaceColorCodes(colorizeUser(obj.from_user));
 	msg = colorizeMentions(msg);
+	msg = colorizeScripts(msg);
 	msg = replaceColorCodes(msg).replace(/\n/g, '<br>');
 
 	return '<span class="timestamp">' + timestr + "</span> " + coloredUser + ' <span class="msg-content">' + msg + '</span>';
@@ -228,4 +250,3 @@ function colorCallback(not_used, p1, p2) {
 function escapeHtml(str) {
 	return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
-


### PR DESCRIPTION
Adds color codes to sub-strings in the format `user.script` in a manner consistent with hackmud and adds a step to `formatMessage()` to parse into `<span>` elements. Addresses #51 