### PR TITLE
Slash color validation [closes #35]

### DIFF
--- a/js/messages.js
+++ b/js/messages.js
@@ -93,9 +93,13 @@ MessageList.prototype.handleSlashCommand = function(str) {
 		}
 	} else if (components[0] == 'color') {
 		if (components[1]) {
-			var color = components[1];
-			settings.setColor(color);
-			this.write('Set chat color to "' + color + '". Sample: "' + colorCallback(null, color, 'foo bar baz') + '"');
+			if (components[1].length == 1){
+				var color = components[1];
+				settings.setColor(color);
+				this.write('Set chat color to "' + color + '". Sample: "' + colorCallback(null, color, 'foo bar baz') + '"');
+			} else {
+				this.write("Please specify a one-character color code.")
+			}
 		} else {
 			if (settings.color_code) {
 				var color = settings.color_code;

--- a/js/messages.js
+++ b/js/messages.js
@@ -99,7 +99,7 @@ MessageList.prototype.handleSlashCommand = function(str) {
 				this.write('Set chat color to "' + color + '". Sample: "' + colorCallback(null, color, 'foo bar baz') + '"');
 			}
 			else {
-				this.write("Invalid color code. Please specify a single letter, or a number in the range 0-5.")
+				this.write("Invalid color code. Please specify a single letter, or a number in the range 0-5.");
 			}
 		} else {
 			if (settings.color_code) {

--- a/js/messages.js
+++ b/js/messages.js
@@ -93,12 +93,13 @@ MessageList.prototype.handleSlashCommand = function(str) {
 		}
 	} else if (components[0] == 'color') {
 		if (components[1]) {
-			if (components[1].length == 1){
+			if(components[1].length == 1 && /^[a-z0-5]$/i.test(components[1])) {
 				var color = components[1];
 				settings.setColor(color);
 				this.write('Set chat color to "' + color + '". Sample: "' + colorCallback(null, color, 'foo bar baz') + '"');
-			} else {
-				this.write("Please specify a one-character color code.")
+			}
+			else {
+				this.write("Invalid color code. Please specify a single letter, or a number in the range 0-5.")
 			}
 		} else {
 			if (settings.color_code) {

--- a/js/messages.js
+++ b/js/messages.js
@@ -93,7 +93,7 @@ MessageList.prototype.handleSlashCommand = function(str) {
 		}
 	} else if (components[0] == 'color') {
 		if (components[1]) {
-			if(components[1].length == 1 && /^[a-z0-5]$/i.test(components[1])) {
+			if(/^[a-z0-5]$/i.test(components[1])) {
 				var color = components[1];
 				settings.setColor(color);
 				this.write('Set chat color to "' + color + '". Sample: "' + colorCallback(null, color, 'foo bar baz') + '"');


### PR DESCRIPTION
Adds length and character validation to the `/color` command, and prints appropriate messages when validation fails. Address #35 