### PR TITLE
Throttle polling for inactive users [closes #17]

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -85,7 +85,7 @@ function Account(last=null) {
 	this.active_user=null;
 	this.last_inactive_user_poll=0;
 }
-Account.inactive_user_poll_delay=6000
+Account.inactive_user_poll_delay=6000;
 Account.prototype.login=function(pass) {
 	if(pass.length>10)return this.update(pass)
 	return API.get_token(pass).then(token=>this.update(token.chat_token))
@@ -162,12 +162,21 @@ Account.prototype.print=function() {
 		this.users[i].print();
 }
 Account.prototype.setActiveUser=function(name) {
-	this.active_user.last_active=Date.now();
-	this.active_user=this.users[name]
+	if(this.active_user)
+		this.active_user.last_active=Date.now();
+
+	this.active_user=this.users[name];
 }
 Account.prototype.getActiveUsers=function(max_inactivity=120000) {
-	let threshold = Date.now() - max_inactivity;
-	return this.users.filter(user=>user === this.active_user || user.last_active > threshold)
+	var threshold=Date.now() - max_inactivity;
+	var users={};
+
+	for(var name in this.users) {
+		if(this.users[name].last_active > threshold || this.active_user && name == this.active_user.name)
+			users[name]=this.users[name];
+	}
+
+	return users;
 }
 
 if(typeof exports!="undefined") {

--- a/js/chat.js
+++ b/js/chat.js
@@ -61,7 +61,8 @@ Channel.prototype.print=function() {
 function User(account,name,dat) {
 	this.account=account;
 	this.name=name;
-	this.channels={}
+	this.last_active=Date.now();
+	this.channels={};
 	for(var i in dat) {
 		this.channels[i]=new Channel(this,i,dat[i]);
 	}
@@ -81,7 +82,10 @@ function Account(last=null) {
 	this.users=null;
 	this.token=null;
 	this.last=last
+	this.active_user=null;
+	this.last_inactive_user_poll=0;
 }
+Account.inactive_user_poll_delay=6000
 Account.prototype.login=function(pass) {
 	if(pass.length>10)return this.update(pass)
 	return API.get_token(pass).then(token=>this.update(token.chat_token))
@@ -103,13 +107,24 @@ Account.prototype.update=function(token) {
 Account.prototype.poll=function(ext={}) {
 	var ar=[];
 	var names=[];
+	var users;
+
 	if(this.last) {
 		if(ext.before=='last')
 			ext.before=this.last+0.001;
 		if(ext.after=='last')
 			ext.after=this.last-0.001;
 	}
-	return API.chats(this.token,Object.keys(this.users),ext)
+
+	if(Date.now() > this.last_inactive_user_poll + Account.inactive_user_poll_delay) {
+		this.last_inactive_user_poll=Date.now();
+		users=this.users;
+	}
+	else {
+		users=this.getActiveUsers();
+	}
+
+	return API.chats(this.token,Object.keys(users),ext)
 	.then(o=>{
 		if(!o.ok)return o;
 		var last=0;
@@ -145,6 +160,14 @@ Account.prototype.print=function() {
 	console.log('  users:')
 	for(var i in this.users)
 		this.users[i].print();
+}
+Account.prototype.setActiveUser=function(name) {
+	this.active_user.last_active=Date.now();
+	this.active_user=this.users[name]
+}
+Account.prototype.getActiveUsers=function(max_inactivity=120000) {
+	let threshold = Date.now() - max_inactivity;
+	return this.users.filter(user=>user === this.active_user || user.last_active > threshold)
 }
 
 if(typeof exports!="undefined") {

--- a/js/ui.js
+++ b/js/ui.js
@@ -140,6 +140,8 @@ function replaceUI() {
 		main_div.append(user_div);
 
 		li.click(function() {
+			act.setActiveUser(name);
+
 			$('.user_tab').removeClass('active');
 			li.addClass('active');
 


### PR DESCRIPTION
Adds "last active" timestamps to users, then throttles the inclusion of users who have been inactive for a while in `chats.json` polling requests. Addresses #17

As it stands, the values used in this PR consider users who haven't been selected in the UI within the last 2 minutes to be "inactive" and throttles their polling to once every ~6 seconds (I shot low here for the sake of maintaining timely tells). "Active" users are still polled at the current 1200ms interval.

I'm not too sure about using the class property `Account.inactive_user_poll_delay` to configure the throttling... It seems like this, the base polling rate, and the default `max_inactivity` value (which differentiates active users from inactive users) should all be part of some static application configuration object.