### PR TITLE
Delay login display [closes #29]

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 			});
 		</script>
 		<div id="chat_pass_login" style="display: none;">
-			to connect enter your <span class="scr-user">chat_pass</span> from in-game: <input onchange="login(this.value)">
+			to connect enter your <span class="scr-user">chat_pass</span> from in-game:
 			<input onchange="login(this.value)">
 			<div id="chat_login_error"></div>
 		</div>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 				ui_ready();
 			});
 		</script>
-		<div id="chat_pass_login">
+		<div id="chat_pass_login" style="display: none;">
 			to connect enter your <span class="scr-user">chat_pass</span> from in-game: <input onchange="login(this.value)">
 		</div>
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,7 +1,10 @@
 function ui_ready() {
 	var token = getToken();
 	if (token) {
-		act.update(token).then(replaceUI);
+		act.update(token).then(replaceUI).catch(function() { $('#chat_pass_login').show(); });
+	}
+	else {
+		$('#chat_pass_login').show();
 	}
 }
 


### PR DESCRIPTION
Defer the login display until no token cookie is found, or `act.update(token)` fails when using the token from cookie. Closes #29 