### PR TITLE
Minor Cleanup

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -119,9 +119,9 @@ Account.prototype.poll=function(ext={}) {
 					.filter(m=>typeof m.channel!="undefined" && (m.is_join || m.is_leave))
 					.forEach(m=>{
 						var ch=this.users[i].channels[m.channel];
-            if(!ch) {
-						  ch=this.users[i].channels[m.channel]=new Channel(this.users[i],m.channel,[]);
-					  }
+            			if(!ch) {
+							ch=this.users[i].channels[m.channel]=new Channel(this.users[i],m.channel,[]);
+						}
 						if(m.is_join) {
 							if(ch.users.indexOf(m.from_user)==-1)
 								ch.users.push(m.from_user);

--- a/js/chat.js
+++ b/js/chat.js
@@ -92,7 +92,6 @@ Account.prototype.update=function(token) {
 	return API.account_data(this.token).then(dat=>{
 		if(!dat.ok)return false;
 		this.users={};
-		var channels=[];
 		for(var i in dat.users) {
 			var name=i
 			this.users[name]=new User(this,name,dat.users[i]);
@@ -101,8 +100,6 @@ Account.prototype.update=function(token) {
 	})
 }
 Account.prototype.poll=function(ext={}) {
-	var ar=[];
-	var names=[];
 	if(this.last) {
 		if(ext.before=='last')
 			ext.before=this.last+0.001;
@@ -110,34 +107,33 @@ Account.prototype.poll=function(ext={}) {
 			ext.after=this.last-0.001;
 	}
 	return API.chats(this.token,Object.keys(this.users),ext)
-	.then(o=>{
-		if(!o.ok)return o;
-		var last=0;
-		for(var i in o.chats) {
-			o.chats[i].sort((a,b)=>a.t-b.t);
-			var l=o.chats[i];
-			if(l.length && l[l.length-1].t>last)
-				last=l[l.length-1].t;
-			o.chats[i]
-				.filter(m=>typeof m.channel!="undefined" && (m.is_join || m.is_leave))
-				.forEach(m=>{
-					var ch=this.users[i].channels[m.channel];
-					if(m.is_join) {
-						if(ch.users.indexOf(m.from_user)==-1)
-							ch.users.push(m.from_user);
-					}
-					if(m.is_leave) {
-						var ind=ch.users.indexOf(m.from_user);
-						for(var ind=ch.users.indexOf(m.from_user);ind!=-1;ind=ch.users.indexOf(m.from_user)) {
-							ch.users.splice(ind,1);
+		.then(o=>{
+			if(!o.ok)return o;
+			var last=0;
+			for(var i in o.chats) {
+				o.chats[i].sort((a,b)=>a.t-b.t);
+				var l=o.chats[i];
+				if(l.length && l[l.length-1].t>last)
+					last=l[l.length-1].t;
+				o.chats[i]
+					.filter(m=>typeof m.channel!="undefined" && (m.is_join || m.is_leave))
+					.forEach(m=>{
+						var ch=this.users[i].channels[m.channel];
+						if(m.is_join) {
+							if(ch.users.indexOf(m.from_user)==-1)
+								ch.users.push(m.from_user);
 						}
-					}
-				})
-		}
-		if(last)
-			this.last=last
-		return o;
-	});
+						if(m.is_leave) {
+							for(var ind=ch.users.indexOf(m.from_user);ind!=-1;ind=ch.users.indexOf(m.from_user)) {
+								ch.users.splice(ind,1);
+							}
+						}
+					})
+			}
+			if(last)
+				this.last=last
+			return o;
+		});
 }
 Account.prototype.print=function() {
 	console.log('Account:');

--- a/js/messages.js
+++ b/js/messages.js
@@ -48,11 +48,11 @@ MessageList.prototype.recordMessage = function (msg) {
 	let msgs = Array.isArray(msg) ? msg : [msg];
 
 	msgs.forEach(m => {
-		id = m.id;
+		let id = m.id;
 		this.messages[id] = m;
 		this.ids.push(id);
 
-		classList = ['message'];
+		let classList = ['message'];
 		if (settings.ignore_list.includes(m.from_user)) {
 			classList.push('ignore');
 		}

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,6 +1,6 @@
 function Settings() {
 	this.ignore_list = [];
-};
+}
 Settings.prototype.setSkipHelp = function(skip) {
 	this.skip_help = !!skip;
 	if(!this.skip_help) {
@@ -11,13 +11,13 @@ Settings.prototype.setSkipHelp = function(skip) {
 }
 
 Settings.prototype.setColor = function(code) {
-	
+
 	if(code == "none") {
 		this.color_code = null;
 		localStorage.removeItem('color_code');
 	} else {
 		this.color_code = code;
-		localStorage.setItem('color_code', JSON.stringify(code));	
+		localStorage.setItem('color_code', JSON.stringify(code));
 	}
 }
 
@@ -40,4 +40,3 @@ Settings.prototype.ready = function() {
 }
 
 var settings = new Settings();
-

--- a/js/ui.js
+++ b/js/ui.js
@@ -284,7 +284,7 @@ function colorizeScripts(msg) {
 		'users'
 	];
 
-	return msg.replace(/(#s.|[^#.a-z0-9_]|^)([a-z_][a-z0-9_]*)\.([a-z_][a-z0-9_]*)/g, function(match, pre, username, script) {
+	return msg.replace(/(#s\.|[^#.a-z0-9_]|^)([a-z_][a-z0-9_]*)\.([a-z_][a-z0-9_]*)/g, function(match, pre, username, script) {
 		let colorCode = trustUsers.indexOf(username) !== -1 ? 'F' : 'C';
 
 		return replaceColorCodes(pre + '`' + colorCode + username + '`.`L' + script + '`');

--- a/js/ui.js
+++ b/js/ui.js
@@ -148,17 +148,17 @@ function setupChannel(user,chan_ul,user_div,chan,tell=false) {
 function replaceUI() {
 	$('#chat_pass_login').hide();
 
-	main_div = $("#chat_area");
+	let main_div = $("#chat_area");
 
 	main_div.innerHTML = ''
 
-	var user_ul = $('<ul class="tab-list">');
+	let user_ul = $('<ul class="tab-list">');
 	let tabset = $('<div class="tabset">');
 	tabset.append(user_ul);
 	main_div.append(tabset);
 
 	for (let name in act.users) {
-		user = act.users[name];
+		let user = act.users[name];
 		if(!user.tells)user.tells={}
 
 		let li = $('<li class="user_tab">');
@@ -200,16 +200,16 @@ function replaceUI() {
 	if (!act.poll_interval) {
 		act.poll_interval = setInterval(function() {
 			act.poll({after:"last"}).then(function(data) {
-				for (user in data.chats) {
+				for (let user in data.chats) {
 					let channels = act.users[user].channels;
 					let tells = act.users[user].tells;
 
 					// new messages, in oldest-to-newest order
 					// TODO deal with tells
-					recent = data.chats[user].filter(m => m.channel && !channels[m.channel].list.messages[m.id]);
+					let recent = data.chats[user].filter(m => m.channel && !channels[m.channel].list.messages[m.id]);
 
 					data.chats[user].filter(m => !m.channel).map(m=> m.from_user==user?m.to_user:m.from_user).forEach(m=>{if(!tells[m]){tells[m]={};setupChannel(act.users[user],act.users[user].chan_ul,act.users[user].user_div,m,true);}});
-					recent_tells = data.chats[user].filter(m => !m.channel && !tells[m.from_user==user?m.to_user:m.from_user].list.messages[m.id]);
+					let recent_tells = data.chats[user].filter(m => !m.channel && !tells[m.from_user==user?m.to_user:m.from_user].list.messages[m.id]);
 
 					recent.forEach(function(msg) {
 						channels[msg.channel].list.recordMessage(msg);
@@ -256,7 +256,7 @@ function colorizeScripts(msg) {
 		'users'
 	];
 
-	return msg.replace(/(#s.|[^#\.a-z0-9_]|^)([a-z_][a-z0-9_]*)\.([a-z_][a-z0-9_]*)/g, function(match, pre, username, script) {
+	return msg.replace(/(#s.|[^#.a-z0-9_]|^)([a-z_][a-z0-9_]*)\.([a-z_][a-z0-9_]*)/g, function(match, pre, username, script) {
 		let colorCode = trustUsers.indexOf(username) !== -1 ? 'F' : 'C';
 
 		return replaceColorCodes(pre + '`' + colorCode + username + '`.`L' + script + '`');


### PR DESCRIPTION
No logic changes; mostly tweaks improving strict-mode compliance. Remove unused variables, and declare undeclared ones (from a biased perspective, helps to trace code flow a little more easily. The added declarations also prevent variables from leaking into the global scope). Removed a duplicate assignment, extraneous semi, and unnecessary escape. Indented `.then()`-on-newline to the de-facto convention. Switched a few defiant newline styles.

There are a lot of redeclared variables in nested scopes, but I don't think there's any clear imperative to change that right now.