### PR TITLE
Multiline input hotfix

### DIFF
--- a/js/messages.js
+++ b/js/messages.js
@@ -16,7 +16,7 @@ MessageList.prototype.poll = function() {
 MessageList.prototype.send = function(msg) {
 	this.scrollToBottom();
 
-	if(msg.length > 1000 || msg.indexOf('\n') > -1 && msg.match(/\n/g).length > 10)
+	if(msg.length > 1000 || (msg.indexOf('\n') > -1 && msg.match(/\n/g).length > 10))
 		this.write('Messages may contain no more than 1000 characters and 10 lines.');
 	else
 		return this.channel.send(msg);

--- a/js/messages.js
+++ b/js/messages.js
@@ -16,7 +16,7 @@ MessageList.prototype.poll = function() {
 MessageList.prototype.send = function(msg) {
 	this.scrollToBottom();
 
-	if(msg.length > 1000 || msg.match(/\n/g).length > 10)
+	if(msg.length > 1000 || msg.indexOf('\n') > -1 && msg.match(/\n/g).length > 10)
 		this.write('Messages may contain no more than 1000 characters and 10 lines.');
 	else
 		return this.channel.send(msg);

--- a/js/ui.js
+++ b/js/ui.js
@@ -111,6 +111,7 @@ function setupChannel(user,chan_ul,user_div,chan,tell=false) {
 			let msg = input.val();
 
 			if(msg.trim().length == 0) {
+				input.val('');
 				return false;
 			}
 


### PR DESCRIPTION
Multiline input PR #87 addressing issue #86 introduced a bug preventing single-line messages from sending - fixes that.

Also, clear message input after attempting to submit a message consisting solely of whitespace.