### PR TITLE
Redirect from bare domain to www

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 	<head>
 		<script>
 			if(document.location.href.startsWith('https://hackmud.com/chat'))
-				document.location.href='https://www.hackmud.com/chat'
+				document.location.href=document.location.href.replace(/^https:\/\/hackmud.com\/chat/,'https://www.hackmud.com/chat');
 		</script>
 		<script src="js/lib/jquery-1.12.4.min.js"></script>
 		<script src="js/chat.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,5 +1,9 @@
 <html>
 	<head>
+		<script>
+			if(document.location.href.startsWith('https://hackmud.com/chat'))
+				document.location.href='https://www.hackmud.com/chat'
+		</script>
 		<script src="js/lib/jquery-1.12.4.min.js"></script>
 		<script src="js/chat.js"></script>
 		<script src="js/init.js"></script>


### PR DESCRIPTION
If you visit https://hackmud.com/chat, you are unable to login because access control checks on the XHR require requests to come from www.hackmud.com. This just adds a super quick and dirty JS redirect to fix the issue. 

A MUCH better fix would be to allow bare-domain in the access checks, or just set up the webserver to 301 bare domain to www. But, I can't exactly do those in the repo, so here's a bad code band-aid instead. 